### PR TITLE
Fix KeyError when empty entries missing

### DIFF
--- a/search_bin/search_n_extract_graphs.py
+++ b/search_bin/search_n_extract_graphs.py
@@ -68,8 +68,8 @@ def atribute_barplot ( att_file = str, index_file = str ,xlabel = '', img_name =
         else:
             clust_dict2[i] = 1
 
-    clust_dict1.pop('')
-    clust_dict2.pop('')
+    clust_dict1.pop('', None)
+    clust_dict2.pop('', None)
 
     ### Se agregan los indices faltantes de clust_dict1 a clust_dict2
     for i in clust_dict1:


### PR DESCRIPTION
## Summary
- handle absent blank entries in `search_n_extract_graphs.py`

## Testing
- `python3 -m py_compile search_bin/search_n_extract_graphs.py`

------
https://chatgpt.com/codex/tasks/task_e_68653f3af5548331aafb1c6beeef19cf